### PR TITLE
Add PremiumModal with feature-based restrictions and modal integration

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,7 +1,14 @@
+import PremiumModal from "@/components/premium/PremiumModal";
+
 export default function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="flex min-h-screen flex-col">{children}</div>;
+  return (
+    <div className="flex min-h-screen flex-col">
+      {children}
+      <PremiumModal />
+    </div>
+  );
 }

--- a/src/app/(main)/resumes/_components/CreateResumeButton.tsx
+++ b/src/app/(main)/resumes/_components/CreateResumeButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import usePremiumModal from "@/hooks/usePremiumModal";
+import { PlusSquare } from "lucide-react";
+import Link from "next/link";
+
+interface CreateResumeButtonProps {
+  canCreate: boolean;
+}
+
+export default function CreateResumeButton({
+  canCreate,
+}: CreateResumeButtonProps) {
+  const premiumModal = usePremiumModal();
+
+  if (canCreate) {
+    return (
+      <Button asChild className="flex gap-2 mx-auto w-fit">
+        <Link href="/create-resume">
+          <PlusSquare size={16} />
+          Create A New Resume
+        </Link>
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      onClick={() => premiumModal.setOpen(true)}
+      className="flex gap-2 mx-auto w-fit"
+    >
+      <PlusSquare size={16} />
+      Create A New Resume
+    </Button>
+  );
+}

--- a/src/app/(main)/resumes/page.tsx
+++ b/src/app/(main)/resumes/page.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@/components/ui/button";
 import prisma from "@/lib/prisma";
+import { resumeDataInclude } from "@/types/create-resume";
 import { withAuth } from "@/utils/withAuth";
 import { User } from "@prisma/client";
-import { PlusSquare, FileText } from "lucide-react";
+import { FileText, PlusSquare } from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
-import { resumeDataInclude } from "@/types/create-resume";
+import CreateResumeButton from "./_components/CreateResumeButton";
 import ResumeItem from "./_components/ResumeItem";
 
 export const metadata: Metadata = {
@@ -31,7 +32,7 @@ export default withAuth(async function Page({ user }: { user: User }) {
   ]);
 
   return (
-    <main className="mx-auto w-full max-w-7xl space-y-6 px-3 py-6">
+    <main className="w-full px-3 py-6 mx-auto space-y-6 max-w-7xl">
       {resumes.length === 0 ? (
         <div className="flex h-[60vh] flex-col items-center justify-center space-y-4 text-center">
           <FileText size={64} />
@@ -41,7 +42,7 @@ export default withAuth(async function Page({ user }: { user: User }) {
           <p className="text-sm text-muted-foreground">
             Create a new resume to get started
           </p>
-          <Button asChild className="mx-auto flex w-fit gap-2">
+          <Button asChild className="flex gap-2 mx-auto w-fit">
             <Link href="/create-resume">
               <PlusSquare size={16} />
               Create A New Resume
@@ -50,19 +51,14 @@ export default withAuth(async function Page({ user }: { user: User }) {
         </div>
       ) : (
         <>
-          <Button asChild className="mx-auto flex w-fit gap-2">
-            <Link href="/create-resume">
-              <PlusSquare size={16} />
-              Create A New Resume
-            </Link>
-          </Button>
+          <CreateResumeButton canCreate={totalCount < 5} />
           <div className="space-y-1">
             <h1 className="text-3xl font-bold">Your Resumes</h1>
             <p className="text-sm text-muted-foreground">
               Resume count: {totalCount}
             </p>
           </div>
-          <div className="flex w-full grid-cols-2 flex-col gap-3 sm:grid md:grid-cols-3 lg:grid-cols-4">
+          <div className="flex flex-col w-full grid-cols-2 gap-3 sm:grid md:grid-cols-3 lg:grid-cols-4">
             {resumes.map((resume, idx) => {
               const untitledIndex = resumes
                 .slice(0, idx + 1)

--- a/src/components/premium/PremiumModal.tsx
+++ b/src/components/premium/PremiumModal.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import usePremiumModal from "@/hooks/usePremiumModal";
+import { FEATURES } from "@/lib/constants";
+import { CheckIcon, SparkleIcon } from "lucide-react";
+import { Button } from "../ui/button";
+import {
+  ResponsiveModal,
+  ResponsiveModalContent,
+  ResponsiveModalHeader,
+  ResponsiveModalTitle,
+} from "../ui/responsive-modal";
+import { Separator } from "../ui/separator";
+
+export default function PremiumModal() {
+  const { open, setOpen } = usePremiumModal();
+
+  const premiumFeatures = FEATURES.filter((feature) => feature.isPremium);
+  const premiumPlusFeatures = premiumFeatures.filter(
+    (feature) => feature.title === "AI-Generated Resume Sections",
+  );
+
+  return (
+    <ResponsiveModal open={open} onOpenChange={setOpen}>
+      <ResponsiveModalContent className="lg:max-w-2xl">
+        <ResponsiveModalHeader>
+          <ResponsiveModalTitle className="mb-6 text-center">
+            Upgrade to Premium
+          </ResponsiveModalTitle>
+        </ResponsiveModalHeader>
+        <div className="flex flex-col items-center space-y-6 sm:flex-row sm:items-center sm:space-x-6 sm:space-y-0">
+          {/* Premium Plan */}
+          <div className="flex flex-col w-full px-4 space-y-5 sm:w-1/2">
+            <h3 className="text-lg font-bold text-center sm:text-left">
+              Premium
+            </h3>
+            <p className="text-sm text-center text-muted-foreground sm:text-left">
+              Unlock the following features:
+            </p>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {premiumFeatures
+                .filter(
+                  (feature) => feature.title !== "AI-Generated Resume Sections",
+                )
+                .slice(0, 2)
+                .map((feature) => (
+                  <li
+                    key={feature.title}
+                    className="flex items-center space-x-2"
+                  >
+                    <CheckIcon className="text-green-500 size-4" />
+                    <span>{feature.title}</span>
+                  </li>
+                ))}
+              <li className="flex items-center space-x-2">
+                <CheckIcon className="text-green-500 size-4" />
+                <span>Create up to 10 resumes</span>
+              </li>
+            </ul>
+            <Button variant="secondary" className="w-full sm:w-auto">
+              Upgrade to Premium
+            </Button>
+          </div>
+
+          {/* Separator */}
+          <Separator
+            orientation="horizontal"
+            className="block w-full sm:hidden"
+          />
+          <Separator
+            orientation="vertical"
+            className="hidden h-full sm:block"
+          />
+
+          {/* Premium Plus Plan */}
+          <div className="flex flex-col w-full px-4 space-y-5 sm:w-1/2">
+            <div className="flex items-center justify-center space-x-2">
+              <SparkleIcon className="w-5 h-5 text-yellow-500" />
+              <h3 className="text-lg font-bold text-transparent bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text">
+                Premium Plus
+              </h3>
+            </div>
+            <p className="text-sm text-center text-muted-foreground sm:text-left">
+              Get everything in Premium, plus:
+            </p>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {premiumPlusFeatures.map((feature) => (
+                <li key={feature.title} className="flex items-center space-x-2">
+                  <CheckIcon className="text-green-500 size-4" />
+                  <span>{feature.title}</span>
+                </li>
+              ))}
+              <li className="flex items-center space-x-2">
+                <CheckIcon className="text-green-500 size-4" />
+                <span>Unlimited resumes</span>
+              </li>
+            </ul>
+            <Button variant="shine" className="w-full sm:w-auto">
+              Upgrade to Premium Plus
+            </Button>
+          </div>
+        </div>
+      </ResponsiveModalContent>
+    </ResponsiveModal>
+  );
+}

--- a/src/hooks/usePremiumModal.ts
+++ b/src/hooks/usePremiumModal.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface PremiumModalState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const usePremiumModal = create<PremiumModalState>(set => ({
+  open: false,
+  setOpen: (open: boolean) => set({ open }),
+}));
+
+export default usePremiumModal;


### PR DESCRIPTION
- Implemented a `PremiumModal` component to prompt users to upgrade to premium plans.
- Integrated Zustand state management to handle modal state (`usePremiumModal`).
- Added `CreateResumeButton` to display the premium modal if the user has exceeded 5 resumes.
-  Hardcoded resume count restriction for free users (up to 5 resumes).
- Enhanced modal with separate Premium and Premium Plus plans:
  - Premium: Access up to 10 resumes and select premium features.
  - Premium Plus: Includes all premium features plus unlimited resumes and AI-powered resume generation.
- Styled the modal to be responsive and maintain consistent design across devices.
- Integrated responsive layout adjustments for better user experience on mobile and desktop.